### PR TITLE
remove str and double quotes at eval/sh for jlink-modules-path

### DIFF
--- a/src/leiningen/jlink.clj
+++ b/src/leiningen/jlink.clj
@@ -99,7 +99,7 @@
       (delete-directory (io/file jlink-path))
       (eval/sh "jlink"
                "--module-path"
-               (str "\"" jlink-modules-path "\"")
+               jlink-modules-path
                "--add-modules"
                jlink-modules
                "--output"


### PR DESCRIPTION
I found that jlink-modules-path does not work in my environment(ubuntu 20.04).
It does not work at OpenJDK 11 and 15.

I don't think it's necessary double quotes with escape for jlink-modules-path, because it is just String.
My pull request version works at OpenJDK 11 and 15.

I'm sorry if I'm mistakes.